### PR TITLE
fixed indexing problem and added metadata tag option in cyftools convert

### DIFF
--- a/src/cell_header.cpp
+++ b/src/cell_header.cpp
@@ -134,9 +134,9 @@ void CellHeader::addTag(const Tag& tag) {
   // this is just the highest existing for that tag type, + 1
   int new_tag_i = 0; 
   for (const auto& t : GetAllTags()) {
-    if (thistag.type == t.type) {
-      new_tag_i = t.i;
-    }
+    //if (thistag.type == t.type) {
+      new_tag_i = t.i; // fixes index issue
+    //}
   }
   
   // add tags to data_tags that store

--- a/src/cell_table.h
+++ b/src/cell_table.h
@@ -58,7 +58,7 @@ public:
   //////
   void BuildTable(const std::string& file);
 
-  void StreamTableCSV(CerealProcessor& proc, const std::string& file);
+  void StreamTableCSV(CerealProcessor& proc, const std::string& file, const std::string& metac);
 
   int StreamTable(CellProcessor& proc, const std::string& file);
   

--- a/src/cyftools.cpp
+++ b/src/cyftools.cpp
@@ -3401,15 +3401,18 @@ int debugfunc(int argc, char** argv) {
 }
 
 static int convertfunc(int argc, char** argv) {
-  const char* shortopts = "s:v";
+  const char* shortopts = "s:vm:";
   //bool mcmicro = false;
   uint32_t sampleid = static_cast<uint32_t>(-1);
+  std::string metacols;
+
   for (char c; (c = getopt_long(argc, argv, shortopts, longopts, NULL)) != -1;) {
     std::istringstream arg(optarg != NULL ? optarg : "");
     switch (c) {
     case 's' : arg >> sampleid; break;
       //case 'c' : mcmicro = true; break;
     case 'v' : opt::verbose = true; break;
+    case 'm' : arg >> metacols; break;
     default: die = true;
     }
   }
@@ -3417,6 +3420,10 @@ static int convertfunc(int argc, char** argv) {
   if (sampleid == static_cast<uint32_t>(-1)) {
     die = true;
   }
+
+  if (metacols.empty()) {
+        die = true;
+    }
   
   if (die || in_out_process(argc, argv)) {
     
@@ -3434,6 +3441,7 @@ static int convertfunc(int argc, char** argv) {
       "Optional Options:\n"
       "  -v, --verbose             Increase output to stderr.\n"
       "  -h,                       Optionally, supply the header text file here, rather than as appended to csv\n"
+      "  -m,                       List metadata headers as a comma-delimited string (i.e. 'Area,Size,LDA')"
       "\n"
       "Example:\n"
       "  cyftools convert input.csv output.cyf\n"
@@ -3445,7 +3453,7 @@ static int convertfunc(int argc, char** argv) {
   CerealProcessor cerp;
   cerp.SetParams(opt::outfile, cmd_input, sampleid);
 
-  table.StreamTableCSV(cerp, opt::infile);
+  table.StreamTableCSV(cerp, opt::infile, metacols);
 
   return 0;
 }


### PR DESCRIPTION
1) commented out if statement lines 137 and 139 in cell_header.cpp
2) edited cell_table.cpp and cell_table.h to accommodate metadata tagging/streaming into cyf table 
3) cyftools convert now has an -m option (see cyftools.cpp) to add custom meta headers